### PR TITLE
Add initial Expo scaffold

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+.expo/
+.DS_Store
+.env

--- a/App.js
+++ b/App.js
@@ -1,0 +1,12 @@
+import React from 'react';
+import { SafeAreaView, Text } from 'react-native';
+import { StatusBar } from 'expo-status-bar';
+
+export default function App() {
+  return (
+    <SafeAreaView className="flex-1 items-center justify-center">
+      <Text className="text-lg font-bold">Welcome to CartCraft!</Text>
+      <StatusBar style="auto" />
+    </SafeAreaView>
+  );
+}

--- a/README.md
+++ b/README.md
@@ -1,1 +1,27 @@
 # CartCraft
+
+Lightweight scaffolding for a React Native app using Expo.
+
+## Tech Stack
+
+- **Frontend:** React Native with Expo
+- **State Management:** Zustand (Context API as backup)
+- **API Calls:** Axios or Fetch to interact with GPT / recipe APIs
+- **Storage:** AsyncStorage locally, Supabase or Firebase for cloud storage
+- **AI:** GPT-4 / OpenAI API with future local inference
+- **UI Kit:** NativeWind (Tailwind-style) or React Native Paper
+- **Deployment:** EAS Build via Expo to App Store and Play Store
+- **Dev Pipeline:** GitHub repo with Expo Go for live preview testing
+
+## Getting Started
+
+1. Install dependencies:
+   ```bash
+   npm install
+   ```
+2. Start development server:
+   ```bash
+   npm start
+   ```
+
+This repo currently contains minimal scaffolding to kick off development. Add screens and components under the `components` directory and stores under `store`.

--- a/app.json
+++ b/app.json
@@ -1,0 +1,18 @@
+{
+  "expo": {
+    "name": "CartCraft",
+    "slug": "cartcraft",
+    "version": "0.1.0",
+    "orientation": "portrait",
+    "icon": "./assets/icon.png",
+    "userInterfaceStyle": "automatic",
+    "splash": {
+      "image": "./assets/splash.png",
+      "resizeMode": "contain",
+      "backgroundColor": "#ffffff"
+    },
+    "assetBundlePatterns": [
+      "**/*"
+    ]
+  }
+}

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,0 +1,7 @@
+module.exports = function(api) {
+  api.cache(true);
+  return {
+    presets: ['babel-preset-expo'],
+    plugins: ['nativewind/babel'],
+  };
+};

--- a/components/RecipeList.js
+++ b/components/RecipeList.js
@@ -1,0 +1,16 @@
+import React from 'react';
+import { View, Text, FlatList } from 'react-native';
+
+export default function RecipeList({ recipes = [] }) {
+  return (
+    <View>
+      <FlatList
+        data={recipes}
+        keyExtractor={(item) => item.id}
+        renderItem={({ item }) => (
+          <Text className="p-2 border-b border-gray-300">{item.title}</Text>
+        )}
+      />
+    </View>
+  );
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "cartcraft",
+  "version": "0.1.0",
+  "private": true,
+  "main": "App.js",
+  "scripts": {
+    "start": "expo start",
+    "android": "expo run:android",
+    "ios": "expo run:ios",
+    "web": "expo start --web"
+  },
+  "dependencies": {
+    "expo": "^50.0.17",
+    "react": "18.2.0",
+    "react-native": "0.73.7",
+    "zustand": "^4.3.7",
+    "axios": "^1.6.5",
+    "nativewind": "^3.3.1"
+  }
+}

--- a/store/useStore.js
+++ b/store/useStore.js
@@ -1,0 +1,9 @@
+import { create } from 'zustand';
+
+const useStore = create(set => ({
+  cart: [],
+  addToCart: item => set(state => ({ cart: [...state.cart, item] })),
+  clearCart: () => set({ cart: [] })
+}));
+
+export default useStore;


### PR DESCRIPTION
## Summary
- add Expo project setup with basic dependencies
- define minimal React Native app and zustand store
- add placeholder recipe list component
- document tech stack in README

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_688a8f706a4c83269016349f9818a5d4