### PR TITLE
Add user preferences store

### DIFF
--- a/store/usePreferences.js
+++ b/store/usePreferences.js
@@ -1,0 +1,38 @@
+import { create } from 'zustand';
+
+// Store for core user preferences and inputs
+const usePreferences = create((set) => ({
+  // Number of people eating the meal
+  numPeople: 1,
+  // Maximum acceptable cook/prep time in minutes
+  maxCookTime: 60,
+  // Budget for the meal or grocery order
+  budget: 0,
+  // Dietary needs such as allergies or restrictions
+  dietaryNeeds: '',
+  // Ingredients or foods the user dislikes
+  dislikes: '',
+  // User's desired emotional outcome for the meal
+  emotionalState: '',
+
+  // Update functions
+  setNumPeople: (num) => set({ numPeople: num }),
+  setMaxCookTime: (time) => set({ maxCookTime: time }),
+  setBudget: (amount) => set({ budget: amount }),
+  setDietaryNeeds: (needs) => set({ dietaryNeeds: needs }),
+  setDislikes: (items) => set({ dislikes: items }),
+  setEmotionalState: (state) => set({ emotionalState: state }),
+
+  // Reset all preferences back to defaults
+  resetPreferences: () =>
+    set({
+      numPeople: 1,
+      maxCookTime: 60,
+      budget: 0,
+      dietaryNeeds: '',
+      dislikes: '',
+      emotionalState: '',
+    }),
+}));
+
+export default usePreferences;


### PR DESCRIPTION
## Summary
- add a Zustand store for collecting user input such as number of people, budget and dietary needs

## Testing
- `npm install` *(fails: No matching version found for nativewind@^3.3.1)*

------
https://chatgpt.com/codex/tasks/task_e_688a950a2c788326b075a0381a4c5964