### PR TITLE
Add proprietary license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,8 @@
+Proprietary License
+
+Copyright (c) 2024 CartCraft contributors
+
+This software is provided for learning and licensed use only. It may not be copied,
+modified, or distributed without first obtaining an appropriate license from the
+copyright holders. Unauthorized use is strictly prohibited.
+

--- a/README.md
+++ b/README.md
@@ -29,3 +29,7 @@ This repo currently contains minimal scaffolding to kick off development. Add sc
 ## Local Content API
 
 The `api/` directory includes a simple content API used during development. It loads JSON files from `api/data/` to mimic server responses. Use `getSplashText` or `getAppContent` from `api/contentApi.js` to access this data.
+
+## License
+
+This project is provided for learning or licensed use only. See [LICENSE](LICENSE) for details.

--- a/package.json
+++ b/package.json
@@ -18,5 +18,6 @@
     "nativewind": "^4.1.23",
     "expo-auth-session": "^4.1.0",
     "expo-apple-authentication": "^5.0.0"
-  }
+  },
+  "license": "SEE LICENSE IN LICENSE"
 }


### PR DESCRIPTION
## Summary
- add proprietary license file specifying that the code is for learning and licensed use only
- document license in README
- set package.json to point to license file

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_688a97246f548326b329a4a38aa1001d