### PR TITLE
Add local-to-remote sync storage module

### DIFF
--- a/App.js
+++ b/App.js
@@ -4,6 +4,7 @@ import { StatusBar } from 'expo-status-bar';
 import { getSplashText } from './api/contentApi';
 import usePlatformAuth from './auth/usePlatformAuth';
 import useStore from './store/useStore';
+import { startSync, stopSync } from './storage/syncedStorage';
 
 export default function App() {
   const [splash, setSplash] = useState('');
@@ -17,6 +18,9 @@ export default function App() {
   useEffect(() => {
     if (user) {
       setUser(user);
+      startSync();
+    } else {
+      stopSync();
     }
   }, [user]);
 

--- a/README.md
+++ b/README.md
@@ -29,3 +29,7 @@ This repo currently contains minimal scaffolding to kick off development. Add sc
 ## Local Content API
 
 The `api/` directory includes a simple content API used during development. It loads JSON files from `api/data/` to mimic server responses. Use `getSplashText` or `getAppContent` from `api/contentApi.js` to access this data.
+
+## Synced Storage
+
+The `storage/` directory contains `syncedStorage.js` which stores data locally using AsyncStorage and periodically backs it up to a remote endpoint. The module automatically pulls user credentials from `useStore` to include with sync requests. Call `startSync()` after login to begin the process.

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "cartcraft",
       "version": "0.1.0",
       "dependencies": {
+        "@react-native-async-storage/async-storage": "^2.2.0",
         "axios": "^1.6.5",
         "expo": "^50.0.17",
         "expo-apple-authentication": "^5.0.0",
@@ -3579,6 +3580,18 @@
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@react-native-async-storage/async-storage": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@react-native-async-storage/async-storage/-/async-storage-2.2.0.tgz",
+      "integrity": "sha512-gvRvjR5JAaUZF8tv2Kcq/Gbt3JHwbKFYfmb445rhOj6NUMx3qPLixmDx5pZAyb9at1bYvJ4/eTUipU5aki45xw==",
+      "license": "MIT",
+      "dependencies": {
+        "merge-options": "^3.0.4"
+      },
+      "peerDependencies": {
+        "react-native": "^0.0.0-0 || >=0.65 <1.0"
       }
     },
     "node_modules/@react-native-community/cli": {
@@ -10775,6 +10788,27 @@
       "resolved": "https://registry.npmjs.org/memory-cache/-/memory-cache-0.2.0.tgz",
       "integrity": "sha512-OcjA+jzjOYzKmKS6IQVALHLVz+rNTMPoJvCztFaZxwG14wtAW7VRZjwTQu06vKCYOxh4jVnik7ya0SXTB0W+xA==",
       "license": "BSD-2-Clause"
+    },
+    "node_modules/merge-options": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/merge-options/-/merge-options-3.0.4.tgz",
+      "integrity": "sha512-2Sug1+knBjkaMsMgf1ctR1Ujx+Ayku4EdJN4Z+C2+JzoeF7A3OZ9KM2GY0CpQS51NR61LTurMJrRKPhSs3ZRTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "is-plain-obj": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/merge-options/node_modules/is-plain-obj": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
+      "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/merge-stream": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -10,13 +10,14 @@
     "web": "expo start --web"
   },
   "dependencies": {
+    "@react-native-async-storage/async-storage": "^2.2.0",
+    "axios": "^1.6.5",
     "expo": "^50.0.17",
+    "expo-apple-authentication": "^5.0.0",
+    "expo-auth-session": "^4.1.0",
+    "nativewind": "^4.1.23",
     "react": "18.2.0",
     "react-native": "0.73.7",
-    "zustand": "^4.3.7",
-    "axios": "^1.6.5",
-    "nativewind": "^4.1.23",
-    "expo-auth-session": "^4.1.0",
-    "expo-apple-authentication": "^5.0.0"
+    "zustand": "^4.3.7"
   }
 }

--- a/storage/syncedStorage.js
+++ b/storage/syncedStorage.js
@@ -1,0 +1,62 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import axios from 'axios';
+import useStore from '../store/useStore';
+
+const STORAGE_PREFIX = 'cc:';
+let intervalId = null;
+
+export async function saveLocal(key, value) {
+  try {
+    await AsyncStorage.setItem(STORAGE_PREFIX + key, JSON.stringify(value));
+  } catch (e) {
+    console.log('Error saving data', e);
+  }
+}
+
+export async function loadLocal(key) {
+  try {
+    const value = await AsyncStorage.getItem(STORAGE_PREFIX + key);
+    return value ? JSON.parse(value) : null;
+  } catch (e) {
+    console.log('Error loading data', e);
+    return null;
+  }
+}
+
+export async function syncToRemote() {
+  try {
+    const keys = (await AsyncStorage.getAllKeys()).filter(k => k.startsWith(STORAGE_PREFIX));
+    const entries = {};
+    for (const k of keys) {
+      const value = await AsyncStorage.getItem(k);
+      if (value !== null) {
+        entries[k.replace(STORAGE_PREFIX, '')] = JSON.parse(value);
+      }
+    }
+    const user = useStore.getState().user;
+    if (!user) {
+      console.log('No user credentials found, skipping sync');
+      return;
+    }
+    await axios.post('https://example.com/api/sync', {
+      user,
+      data: entries,
+    });
+  } catch (err) {
+    console.log('Error syncing data', err);
+  }
+}
+
+export function startSync(intervalMs = 60000) {
+  if (intervalId) {
+    clearInterval(intervalId);
+  }
+  intervalId = setInterval(syncToRemote, intervalMs);
+}
+
+export function stopSync() {
+  if (intervalId) {
+    clearInterval(intervalId);
+    intervalId = null;
+  }
+}


### PR DESCRIPTION
## Summary
- add AsyncStorage dependency
- create `storage/syncedStorage` for local/remote data backup
- start syncing after login in `App.js`
- document usage in README

## Testing
- `npm run lint` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_688a9920eda48326b348b3caeb762f6d