### PR TITLE
Add meal plan viewer module

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,12 @@ This repo currently contains minimal scaffolding to kick off development. Add sc
 
 The `api/` directory includes a simple content API used during development. It loads JSON files from `api/data/` to mimic server responses. Use `getSplashText` or `getAppContent` from `api/contentApi.js` to access this data.
 
+## Meal Plans
+
+Plan meals using the `useMealPlans` store and display them over different time
+periods with the `MealPlanViewer` component. Supported periods are per meal, per
+day, per week and per year.
+
 ## License
 
 This project is provided for learning or licensed use only. See [LICENSE](LICENSE) for details.

--- a/components/MealPlanViewer.js
+++ b/components/MealPlanViewer.js
@@ -1,0 +1,58 @@
+import React from 'react';
+import { View, Text } from 'react-native';
+
+// Helper to get a week key like "2025-W27"
+function getWeekKey(date) {
+  const firstDay = new Date(date.getFullYear(), 0, 1);
+  const dayOfYear = Math.floor((date - firstDay) / (24 * 60 * 60 * 1000));
+  const week = Math.ceil((dayOfYear + firstDay.getDay() + 1) / 7);
+  return `${date.getFullYear()}-W${week}`;
+}
+
+function groupPlans(plans, period) {
+  const groups = {};
+  plans.forEach((plan) => {
+    const date = new Date(plan.date);
+    let key;
+    switch (period) {
+      case 'day':
+        key = date.toISOString().split('T')[0];
+        break;
+      case 'week':
+        key = getWeekKey(date);
+        break;
+      case 'year':
+        key = date.getFullYear().toString();
+        break;
+      case 'meal':
+      default:
+        key = plan.id.toString();
+    }
+    if (!groups[key]) groups[key] = [];
+    groups[key].push(plan);
+  });
+  return groups;
+}
+
+export default function MealPlanViewer({ plans = [], period = 'meal' }) {
+  const groups = groupPlans(plans, period);
+  return (
+    <View>
+      {Object.entries(groups).map(([key, items]) => (
+        <View key={key} className="mb-4">
+          {period !== 'meal' && (
+            <Text className="text-lg font-bold mb-2">{key}</Text>
+          )}
+          {items.map((plan) => (
+            <Text
+              key={plan.id}
+              className="p-2 border-b border-gray-300"
+            >
+              {plan.title} - {new Date(plan.date).toLocaleString()}
+            </Text>
+          ))}
+        </View>
+      ))}
+    </View>
+  );
+}

--- a/store/useMealPlans.js
+++ b/store/useMealPlans.js
@@ -1,0 +1,12 @@
+import { create } from 'zustand';
+
+// Store for managing planned meals
+const useMealPlans = create((set) => ({
+  // Array of meal plan objects: { id, title, date }
+  plans: [],
+  addPlan: (plan) =>
+    set((state) => ({ plans: [...state.plans, plan] })),
+  clearPlans: () => set({ plans: [] }),
+}));
+
+export default useMealPlans;


### PR DESCRIPTION
## Summary
- add `MealPlanViewer` component for displaying planned meals
- create zustand store `useMealPlans` to manage meal data
- document meal plan usage in README

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_688a99f3e0008326bfad2fe2e86add6c