### PR TITLE
Hook meal plans to storage and add cloud opt-out

### DIFF
--- a/App.js
+++ b/App.js
@@ -1,33 +1,45 @@
 import React, { useEffect, useState } from 'react';
-import { SafeAreaView, Text, Button } from 'react-native';
+import { SafeAreaView, Text, Button, Switch, View } from 'react-native';
 import { StatusBar } from 'expo-status-bar';
 import { getSplashText } from './api/contentApi';
 import usePlatformAuth from './auth/usePlatformAuth';
 import useStore from './store/useStore';
+import useMealPlans from './store/useMealPlans';
 import { startSync, stopSync } from './storage/syncedStorage';
 
 export default function App() {
   const [splash, setSplash] = useState('');
   const { signIn, user } = usePlatformAuth();
   const setUser = useStore(state => state.setUser);
+  const cloudOptOut = useStore(state => state.cloudOptOut);
+  const setCloudOptOut = useStore(state => state.setCloudOptOut);
+  const loadPlans = useMealPlans(state => state.loadPlans);
 
   useEffect(() => {
     getSplashText().then(setSplash);
+    loadPlans();
   }, []);
 
   useEffect(() => {
-    if (user) {
+    if (user && !cloudOptOut) {
       setUser(user);
       startSync();
     } else {
       stopSync();
     }
-  }, [user]);
+  }, [user, cloudOptOut]);
 
   return (
     <SafeAreaView className="flex-1 items-center justify-center">
       <Text className="text-lg font-bold">{splash}</Text>
       <Button title="Sign In" onPress={signIn} />
+      <View className="mt-4 flex-row items-center">
+        <Text className="mr-2">Cloud Storage & Analytics</Text>
+        <Switch
+          value={!cloudOptOut}
+          onValueChange={(val) => setCloudOptOut(!val)}
+        />
+      </View>
       <StatusBar style="auto" />
     </SafeAreaView>
   );

--- a/storage/syncedStorage.js
+++ b/storage/syncedStorage.js
@@ -25,6 +25,11 @@ export async function loadLocal(key) {
 
 export async function syncToRemote() {
   try {
+    const { user, cloudOptOut } = useStore.getState();
+    if (cloudOptOut) {
+      console.log('Cloud sync disabled by user');
+      return;
+    }
     const keys = (await AsyncStorage.getAllKeys()).filter(k => k.startsWith(STORAGE_PREFIX));
     const entries = {};
     for (const k of keys) {
@@ -33,7 +38,6 @@ export async function syncToRemote() {
         entries[k.replace(STORAGE_PREFIX, '')] = JSON.parse(value);
       }
     }
-    const user = useStore.getState().user;
     if (!user) {
       console.log('No user credentials found, skipping sync');
       return;

--- a/store/useMealPlans.js
+++ b/store/useMealPlans.js
@@ -1,12 +1,26 @@
 import { create } from 'zustand';
+import { saveLocal, loadLocal } from '../storage/syncedStorage';
+
+const STORAGE_KEY = 'mealPlans';
 
 // Store for managing planned meals
 const useMealPlans = create((set) => ({
   // Array of meal plan objects: { id, title, date }
   plans: [],
   addPlan: (plan) =>
-    set((state) => ({ plans: [...state.plans, plan] })),
-  clearPlans: () => set({ plans: [] }),
+    set((state) => {
+      const plans = [...state.plans, plan];
+      saveLocal(STORAGE_KEY, plans);
+      return { plans };
+    }),
+  clearPlans: () => {
+    saveLocal(STORAGE_KEY, []);
+    set({ plans: [] });
+  },
+  loadPlans: async () => {
+    const stored = await loadLocal(STORAGE_KEY);
+    set({ plans: stored || [] });
+  },
 }));
 
 export default useMealPlans;

--- a/store/useStore.js
+++ b/store/useStore.js
@@ -3,7 +3,9 @@ import { create } from 'zustand';
 const useStore = create(set => ({
   cart: [],
   user: null,
+  cloudOptOut: false,
   setUser: user => set({ user }),
+  setCloudOptOut: cloudOptOut => set({ cloudOptOut }),
   addToCart: item => set(state => ({ cart: [...state.cart, item] })),
   clearCart: () => set({ cart: [] })
 }));


### PR DESCRIPTION
## Summary
- persist meal plans using synced storage
- add cloud opt-out setting in store
- honor opt-out in sync code and show toggle in the app
- load saved meal plans on start

## Testing
- `npm test` *(fails: Invalid package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688a9bbbda088326ac9e9d657d654488