### PR TITLE
Add advertiser upsell integration module

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,10 @@ day, per week and per year.
 
 The `storage/` directory contains `syncedStorage.js` which stores data locally using AsyncStorage and periodically backs it up to a remote endpoint. The module automatically pulls user credentials from `useStore` to include with sync requests. Call `startSync()` after login to begin the process.
 
+## Advertiser Integration
+
+The `advertising/` directory provides `adsApi.js` and bundled JSON data used to pull sponsored upsell suggestions. Use the `useUpsellAds` store to load offers that can be shown alongside recommendations from your decision engine.
+
 ## License
 
 This project is provided for learning or licensed use only. See [LICENSE](LICENSE) for details.

--- a/advertising/adsApi.js
+++ b/advertising/adsApi.js
@@ -1,0 +1,18 @@
+import axios from 'axios';
+import upsellData from './data/upsellAds.json';
+
+// Fetch upsell advertising offers.
+// Attempts remote call first, falls back to bundled data if offline
+export async function fetchUpsellAds(context = {}) {
+  try {
+    const resp = await axios.post('https://example.com/api/ads/upsell', { context });
+    return resp.data.ads || [];
+  } catch (err) {
+    console.log('Remote ads unavailable, using local data', err);
+    // Basic filtering by category when available
+    if (context.category) {
+      return upsellData.ads.filter(ad => ad.category === context.category);
+    }
+    return upsellData.ads;
+  }
+}

--- a/advertising/data/upsellAds.json
+++ b/advertising/data/upsellAds.json
@@ -1,0 +1,18 @@
+{
+  "ads": [
+    {
+      "id": "ad1",
+      "title": "Premium Organic Tomato Sauce",
+      "category": "grocery",
+      "description": "Upgrade your meal with the richest organic sauce.",
+      "price": 6.99
+    },
+    {
+      "id": "ad2",
+      "title": "Chef's Grade Stainless Pan",
+      "category": "cookware",
+      "description": "Cook like a professional with this high quality pan.",
+      "price": 49.99
+    }
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -17,8 +17,8 @@
     "expo-auth-session": "^4.1.0",
     "nativewind": "^4.1.23",
     "react": "18.2.0",
-    "react-native": "0.73.7",    
-    "zustand": "^4.3.7",
+    "react-native": "0.73.7",
+    "zustand": "^4.3.7"
   },
   "license": "SEE LICENSE IN LICENSE"
 }

--- a/store/useUpsellAds.js
+++ b/store/useUpsellAds.js
@@ -1,0 +1,14 @@
+import { create } from 'zustand';
+import { fetchUpsellAds } from '../advertising/adsApi';
+
+const useUpsellAds = create((set) => ({
+  ads: [],
+  // Load ads related to a decision context
+  loadAds: async (context) => {
+    const ads = await fetchUpsellAds(context);
+    set({ ads });
+  },
+  clearAds: () => set({ ads: [] }),
+}));
+
+export default useUpsellAds;


### PR DESCRIPTION
## Summary
- integrate an advertising module for upsell results
- add zustand store for sponsored ads
- fix trailing comma in `package.json`
- document advertiser integration in README

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_688a9c29a1048326b7d14e0662b46ce4