### PR TITLE
Implement local recipe API

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,9 @@ This repo currently contains minimal scaffolding to kick off development. Add sc
 
 The `api/` directory includes a simple content API used during development. It loads JSON files from `api/data/` to mimic server responses. Use `getSplashText` or `getAppContent` from `api/contentApi.js` to access this data.
 
+### Local Recipe API
+`api/recipeApi.js` works the same way for recipes, returning data from `api/data/recipes.json`. In production this module will call the Spoonacular API instead of local JSON files.
+
 ## Meal Plans
 
 Plan meals using the `useMealPlans` store and display them over different time

--- a/api/data/recipes.json
+++ b/api/data/recipes.json
@@ -1,0 +1,14 @@
+[
+  {
+    "id": "1",
+    "title": "Spaghetti Bolognese",
+    "ingredients": ["spaghetti", "ground beef", "tomato sauce"],
+    "instructions": "Cook pasta. Brown beef. Mix with sauce. Combine."
+  },
+  {
+    "id": "2",
+    "title": "Chicken Stir Fry",
+    "ingredients": ["chicken", "vegetables", "soy sauce"],
+    "instructions": "Stir fry chicken and veggies. Add sauce. Serve with rice."
+  }
+]

--- a/api/recipeApi.js
+++ b/api/recipeApi.js
@@ -1,0 +1,15 @@
+// Local recipe API for development/testing
+// Loads static JSON files that mimic remote API responses.
+
+import recipes from './data/recipes.json';
+
+export async function getRecipes() {
+  return new Promise((resolve) => {
+    setTimeout(() => resolve(recipes), 200);
+  });
+}
+
+export async function getRecipe(id) {
+  const all = await getRecipes();
+  return all.find((r) => r.id === id);
+}

--- a/package.json
+++ b/package.json
@@ -17,8 +17,8 @@
     "expo-auth-session": "^4.1.0",
     "nativewind": "^4.1.23",
     "react": "18.2.0",
-    "react-native": "0.73.7",    
-    "zustand": "^4.3.7",
+    "react-native": "0.73.7",
+    "zustand": "^4.3.7"
   },
   "license": "SEE LICENSE IN LICENSE"
 }


### PR DESCRIPTION
## Summary
- add a simple recipeApi module that loads local JSON data
- include a sample recipes.json dataset
- note Spoonacular in the README
- fix package.json trailing comma so npm commands can parse

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_688a9d0a391083268e16bea07b8b46a4