### PR TITLE
Add analytics task scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,8 @@ node_modules/
 .expo/
 .DS_Store
 .env
+
+# Analytics output
+analytics/export.json
+analytics/deidentified.json
+analytics/insights.json

--- a/analytics/README.md
+++ b/analytics/README.md
@@ -1,0 +1,40 @@
+# Analytics Tasks
+
+This directory contains sample scripts that demonstrate how to extract,
+de-identify and generate aggregated insights from user meal data.
+
+The data in `sampleData.json` is placeholder data for demonstration only.
+
+## Task 1: Export raw data
+Run the extraction script which would normally connect to your database
+and fetch user records.
+
+```bash
+node analytics/extractData.js
+```
+
+The script outputs `analytics/export.json`.
+
+## Task 2: De-identify records
+Remove personal identifiers and pseudonymize user IDs.
+
+```bash
+node analytics/deidentify.js
+```
+
+This produces `analytics/deidentified.json` containing sanitized data.
+
+## Task 3: Generate insights
+Create aggregated statistics from the de-identified data that can be
+shared with retailers.
+
+```bash
+node analytics/generateInsights.js
+```
+
+Aggregated results are written to `analytics/insights.json`.
+
+## Notes
+Ensure that you have the rights to process this data and that the
+resulting output meets the legal definition of anonymized or
+aggregated information in your jurisdiction before sharing it externally.

--- a/analytics/deidentify.js
+++ b/analytics/deidentify.js
@@ -1,0 +1,31 @@
+// Remove personal identifiers from exported data.
+// Replaces userId with hashed value and strips any extra PII fields.
+
+const fs = require("fs");
+const crypto = require("crypto");
+
+const INPUT_PATH = './analytics/export.json';
+const OUTPUT_PATH = './analytics/deidentified.json';
+
+function hash(value) {
+  return crypto.createHash('sha256').update(value).digest('hex');
+}
+
+function run() {
+  try {
+    const raw = fs.readFileSync(INPUT_PATH, 'utf8');
+    const data = JSON.parse(raw);
+    const cleaned = data.map((rec) => ({
+      id: hash(String(rec.userId)),
+      mealPlans: rec.mealPlans,
+      preferences: rec.preferences,
+    }));
+    fs.writeFileSync(OUTPUT_PATH, JSON.stringify(cleaned, null, 2));
+    console.log('De-identified data saved to', OUTPUT_PATH);
+  } catch (err) {
+    console.error('De-identification failed', err);
+    process.exit(1);
+  }
+}
+
+run();

--- a/analytics/extractData.js
+++ b/analytics/extractData.js
@@ -1,0 +1,28 @@
+// Script to export meal and preference data for analytics.
+// In a real environment this would connect to your database.
+// For the sample repo we read from a placeholder JSON file.
+
+const fs = require("fs");
+
+const INPUT_PATH = './analytics/sampleData.json'; // replace with real path
+const OUTPUT_PATH = './analytics/export.json';
+
+function run() {
+  try {
+    const raw = fs.readFileSync(INPUT_PATH, 'utf8');
+    const data = JSON.parse(raw);
+    // Filter only fields needed for analytics
+    const exported = data.map(({ userId, mealPlans, preferences }) => ({
+      userId, // will be pseudonymized later
+      mealPlans,
+      preferences,
+    }));
+    fs.writeFileSync(OUTPUT_PATH, JSON.stringify(exported, null, 2));
+    console.log('Data exported to', OUTPUT_PATH);
+  } catch (err) {
+    console.error('Export failed', err);
+    process.exit(1);
+  }
+}
+
+run();

--- a/analytics/generateInsights.js
+++ b/analytics/generateInsights.js
@@ -1,0 +1,34 @@
+// Generate aggregated statistics from de-identified data.
+
+const fs = require("fs");
+
+const INPUT_PATH = './analytics/deidentified.json';
+const OUTPUT_PATH = './analytics/insights.json';
+
+function run() {
+  try {
+    const raw = fs.readFileSync(INPUT_PATH, 'utf8');
+    const data = JSON.parse(raw);
+
+    // Example insight: count of meal plans per preference type
+    const counts = {};
+    for (const rec of data) {
+      for (const pref of rec.preferences || []) {
+        counts[pref] = (counts[pref] || 0) + 1;
+      }
+    }
+
+    const insights = {
+      preferenceCounts: counts,
+      totalRecords: data.length,
+    };
+
+    fs.writeFileSync(OUTPUT_PATH, JSON.stringify(insights, null, 2));
+    console.log('Insights written to', OUTPUT_PATH);
+  } catch (err) {
+    console.error('Insight generation failed', err);
+    process.exit(1);
+  }
+}
+
+run();

--- a/analytics/sampleData.json
+++ b/analytics/sampleData.json
@@ -1,0 +1,17 @@
+[
+  {
+    "userId": "user1",
+    "mealPlans": [
+      {"id": 1, "title": "Plan A"},
+      {"id": 2, "title": "Plan B"}
+    ],
+    "preferences": ["vegan", "low-carb"]
+  },
+  {
+    "userId": "user2",
+    "mealPlans": [
+      {"id": 3, "title": "Plan C"}
+    ],
+    "preferences": ["vegetarian"]
+  }
+]


### PR DESCRIPTION
## Summary
- add scripts for data extraction, de-identification and insight generation
- document how to run the analytics tasks
- ignore generated analytics output files

## Testing
- `node analytics/extractData.js && node analytics/deidentify.js && node analytics/generateInsights.js`

------
https://chatgpt.com/codex/tasks/task_e_688a9bf36fd8832692992b0b739d6dee