### PR TITLE
Add ingredient-based recipe search module

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,9 @@ The `api/` directory includes a simple content API used during development. It l
 ### Local Recipe API
 `api/recipeApi.js` works the same way for recipes, returning data from `api/data/recipes.json`. In production this module will call the Spoonacular API instead of local JSON files.
 
+### Recipe Search
+Use `searchRecipesByIngredients()` from `api/recipeSearch.js` to find recipes that can be made with ingredients you have available. The function attempts to query a remote endpoint and falls back to filtering the local recipe data when offline.
+
 ## Meal Plans
 
 Plan meals using the `useMealPlans` store and display them over different time

--- a/api/recipeSearch.js
+++ b/api/recipeSearch.js
@@ -1,0 +1,27 @@
+import axios from 'axios';
+import { getRecipes } from './recipeApi';
+
+// Search for recipes that can be made with the provided ingredients.
+// Attempts to query the remote API first and falls back to local data
+// if the network request fails.
+export async function searchRecipesByIngredients(ingredients = []) {
+  if (!Array.isArray(ingredients) || ingredients.length === 0) {
+    return [];
+  }
+
+  try {
+    const resp = await axios.post('https://example.com/api/recipes/search', {
+      ingredients,
+    });
+    return resp.data.recipes || [];
+  } catch (err) {
+    console.log('Remote recipe search failed, using local data', err);
+    const all = await getRecipes();
+    const normalized = ingredients.map((i) => i.toLowerCase());
+    return all.filter((rec) =>
+      normalized.every((ing) =>
+        rec.ingredients.map((r) => r.toLowerCase()).includes(ing)
+      )
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add a recipe search helper that tries a remote API but filters local recipes if offline
- document the new `searchRecipesByIngredients` utility

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_688aa3209b4883269fab7079d7135afd