### PR TITLE
Add Walmart API module

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,9 @@ The `api/` directory includes a simple content API used during development. It l
 ### Local Recipe API
 `api/recipeApi.js` works the same way for recipes, returning data from `api/data/recipes.json`. In production this module will call the Spoonacular API instead of local JSON files.
 
+### Walmart Product API
+`api/walmartApi.js` retrieves product listings and prices from the Walmart API. When the remote service is unavailable, it returns sample results from `api/data/walmartSample.json`. Set the `WALMART_API_KEY` environment variable to enable live queries.
+
 ## Meal Plans
 
 Plan meals using the `useMealPlans` store and display them over different time

--- a/api/data/walmartSample.json
+++ b/api/data/walmartSample.json
@@ -1,0 +1,7 @@
+{
+  "items": [
+    { "itemId": 1, "name": "Sample Product A", "salePrice": 9.99 },
+    { "itemId": 2, "name": "Sample Product B", "salePrice": 19.99 },
+    { "itemId": 3, "name": "Sample Product C", "salePrice": 5.49 }
+  ]
+}

--- a/api/walmartApi.js
+++ b/api/walmartApi.js
@@ -1,0 +1,37 @@
+import axios from 'axios';
+import sampleData from './data/walmartSample.json';
+
+const API_BASE = 'https://developer.api.walmart.com/api-proxy/service/affil/product/v2';
+const API_KEY = process.env.WALMART_API_KEY;
+
+// Search for products by query string using Walmart's public API.
+// Returns an array of items with price information.
+export async function searchProducts(query, opts = {}) {
+  if (!query) return [];
+  try {
+    const params = { query, apiKey: API_KEY, format: 'json', ...opts };
+    const resp = await axios.get(`${API_BASE}/search`, { params });
+    if (resp.data?.items) {
+      return resp.data.items;
+    }
+    if (resp.data?.searchItemCollection?.items) {
+      return resp.data.searchItemCollection.items;
+    }
+    return resp.data || [];
+  } catch (err) {
+    console.log('Error fetching Walmart products, using sample data', err);
+    return sampleData.items.filter(item => item.name.toLowerCase().includes(query.toLowerCase()));
+  }
+}
+
+// Retrieve a single product by item ID.
+export async function getProduct(itemId) {
+  try {
+    const params = { apiKey: API_KEY, format: 'json' };
+    const resp = await axios.get(`${API_BASE}/items/${itemId}`, { params });
+    return resp.data;
+  } catch (err) {
+    console.log('Error fetching Walmart product', err);
+    return sampleData.items.find(item => item.itemId === itemId);
+  }
+}


### PR DESCRIPTION
## Summary
- implement `api/walmartApi.js` for fetching product data from Walmart API
- include fallback sample dataset `api/data/walmartSample.json`
- document Walmart Product API module in README

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_688aa3d5fb448326bf0db341d24d9523