### PR TITLE
Add Amazon API module

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ The `api/` directory includes a simple content API used during development. It l
 
 ### Walmart Product API
 `api/walmartApi.js` retrieves product listings and prices from the Walmart API. When the remote service is unavailable, it returns sample results from `api/data/walmartSample.json`. Set the `WALMART_API_KEY` environment variable to enable live queries.
+### Amazon Product API
+`api/amazonApi.js` queries Amazon for product information and pricing. If the network request fails the module falls back to `api/data/amazonSample.json`. Set the `AMAZON_API_KEY` environment variable to enable live lookups.
 ### Recipe Search
 Use `searchRecipesByIngredients()` from `api/recipeSearch.js` to find recipes that can be made with ingredients you have available. The function attempts to query a remote endpoint and falls back to filtering the local recipe data when offline.
 

--- a/api/amazonApi.js
+++ b/api/amazonApi.js
@@ -1,0 +1,36 @@
+import axios from 'axios';
+import sampleData from './data/amazonSample.json';
+
+const API_BASE = 'https://api.amazon.com/products';
+const API_KEY = process.env.AMAZON_API_KEY;
+
+// Search for products by query string using Amazon's public API.
+// Returns an array of products with pricing details.
+export async function searchProducts(query, opts = {}) {
+  if (!query) return [];
+  try {
+    const params = { query, apiKey: API_KEY, ...opts };
+    const resp = await axios.get(`${API_BASE}/search`, { params });
+    if (resp.data?.products) {
+      return resp.data.products;
+    }
+    return resp.data || [];
+  } catch (err) {
+    console.log('Error fetching Amazon products, using sample data', err);
+    return sampleData.products.filter(p =>
+      p.title.toLowerCase().includes(query.toLowerCase())
+    );
+  }
+}
+
+// Retrieve a single product by ASIN.
+export async function getProduct(asin) {
+  try {
+    const params = { apiKey: API_KEY };
+    const resp = await axios.get(`${API_BASE}/items/${asin}`, { params });
+    return resp.data;
+  } catch (err) {
+    console.log('Error fetching Amazon product', err);
+    return sampleData.products.find(p => p.asin === asin);
+  }
+}

--- a/api/data/amazonSample.json
+++ b/api/data/amazonSample.json
@@ -1,0 +1,7 @@
+{
+  "products": [
+    { "asin": "B001", "title": "Amazon Sample Product A", "price": 12.99 },
+    { "asin": "B002", "title": "Amazon Sample Product B", "price": 25.5 },
+    { "asin": "B003", "title": "Amazon Sample Product C", "price": 7.99 }
+  ]
+}


### PR DESCRIPTION
## Summary
- add `api/amazonApi.js` to fetch products from a hypothetical Amazon API
- include fallback data in `api/data/amazonSample.json`
- document the new module in README

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_688aa6454a44832697acbe8e4bb296d8