### PR TITLE
Add ingredient consolidation utility

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,9 @@ The `api/` directory includes a simple content API used during development. It l
 ### Recipe Search
 Use `searchRecipesByIngredients()` from `api/recipeSearch.js` to find recipes that can be made with ingredients you have available. The function attempts to query a remote endpoint and falls back to filtering the local recipe data when offline.
 
+### Ingredient Consolidation
+`utils/ingredientUtils.js` exposes `consolidateIngredients()` which merges the ingredient lists from selected recipes. Pass in the meal objects and the number of diners to get a combined shopping list scaled for that party size.
+
 ## Meal Plans
 
 Plan meals using the `useMealPlans` store and display them over different time

--- a/utils/ingredientUtils.js
+++ b/utils/ingredientUtils.js
@@ -1,0 +1,35 @@
+export function consolidateIngredients(meals = [], numPeople = 1) {
+  const totals = {};
+  meals.forEach((meal) => {
+    if (!Array.isArray(meal.ingredients)) return;
+    meal.ingredients.forEach((ing) => {
+      if (!ing) return;
+      let name;
+      let qty = 1;
+      let unit;
+
+      if (typeof ing === 'string') {
+        name = ing;
+      } else if (typeof ing === 'object') {
+        name = ing.name;
+        qty = ing.quantity ?? 1;
+        unit = ing.unit;
+      }
+
+      if (!name) return;
+
+      const scaled = qty * numPeople;
+      if (totals[name]) {
+        totals[name].quantity += scaled;
+      } else {
+        totals[name] = { quantity: scaled, unit };
+      }
+    });
+  });
+
+  return Object.entries(totals).map(([name, info]) => ({
+    name,
+    quantity: info.quantity,
+    unit: info.unit,
+  }));
+}


### PR DESCRIPTION
## Summary
- add `consolidateIngredients` in `utils/ingredientUtils.js` for merging ingredient lists
- document the new helper in the README

## Testing
- `node -e "import('./utils/ingredientUtils.js').then(m=>console.log(m.consolidateIngredients([{ingredients:['eggs','milk']},{ingredients:[{name:'milk',quantity:2,unit:'cups'}]}],2)))"`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_688aa9247ad48326a241720ac248e109